### PR TITLE
stretch one-seat house primary results to full-width; closes #131

### DIFF
--- a/src/js/components/house-primary/house-primary.less
+++ b/src/js/components/house-primary/house-primary.less
@@ -1,10 +1,6 @@
 @import "../../../css/values.less";
 
 house-primary {
-  .embed-row & .chatter {
-    display: none;
-  }  
-
   .results {
     display: flex;
     flex-wrap: wrap;
@@ -58,6 +54,18 @@ house-primary {
       }
     }
   }
+}
 
+// embed-specific overrides
+.embed-row house-primary {
+  .chatter {
+    display: none;
+  }
 
+  // if this is a one-district embed, 
+  // and there's only one seat up for election,
+  // stretch it full-width
+  &[district] house-seat[data-count="1"] {
+    flex-basis: 100%;
+  }
 }


### PR DESCRIPTION
tested against AL house results for 3/5

/embeds/?live=&race=H&data=AL_H_3_5_2024

/embeds/?live=&race=H&data=AL_H_3_5_2024&district=3

/states/AL.html?eternal#date=3%2F5%2F2024&office=H