### PR TITLE
apply footnotes to house / senate races. closes #157

### DIFF
--- a/src/js/components/house-primary/index.js
+++ b/src/js/components/house-primary/index.js
@@ -85,7 +85,12 @@ class HousePrimary extends ElementBase {
     var groupedResults = groupBy(this.cache.races, "seat");
     var seats = Object.keys(groupedResults).map(function(id) {
       return {
-        results: groupedResults[id].map(r => r.results[0]),
+        results: groupedResults[id].map(function(r) {
+          if (typeof(r.footnote) != "undefined") {
+            r.results[0].footnote = r.footnote;
+          }
+          return r.results[0];
+        }),
         id,
         state: groupedResults[id][0].state
       }
@@ -108,16 +113,22 @@ class HousePrimary extends ElementBase {
       // create result tables
       var pairs = mapToElements(seatElements.results, race.results, "results-table");
 
+      // console.log(seatElements.results, race.results);
+
       // render each one
       var test = !!this.cache.test;
 
       pairs.forEach(function([data, child]) {
         if (href) child.setAttribute("href", href);
         child.setAttribute("max", 99);
-        toggleAttribute(child, "test", test);
 
+        toggleAttribute(child, "test", test);
         toggleAttribute(child, "hidden", party && data.party != party);
         
+        if (data.id == "82157") {
+          console.log(data, child);
+        }
+
         var readableParty = general ? "" : 
           data.party == "Dem" ? "Democratic" : data.party == "GOP" ? "Republican" : (data.party || "Open");
         var raceType = general ? "election" : "primary";

--- a/src/js/components/results-table/index.js
+++ b/src/js/components/results-table/index.js
@@ -68,7 +68,8 @@ class ResultsTable extends ElementBase {
       reporting,
       reportingPercentage,
       updated,
-      eevp
+      eevp,
+      footnote
     } = result;
 
     // copy the array before mutating
@@ -80,6 +81,10 @@ class ResultsTable extends ElementBase {
       candidates.length > 1
         ? ""
         : "The AP does not tabulate votes for uncontested races and declares its winner as soon as polls close.";
+
+    if (result.footnote) {
+      elements.footnote.innerHTML = result.footnote + " " + elements.footnote.innerHTML;
+    }
 
     this.setAttribute("party", party);
     // normalize percentages
@@ -174,6 +179,11 @@ class ResultsTable extends ElementBase {
         reporting_string = ">99% precincts reporting";
       } else {
         reporting_string = result.reportingPercentage.toFixed(0).toString() + "% precincts reporting";
+      }
+
+      // add footnote if one exists (specified in `footnotes` sheet)
+      if (footnote) {
+        elements.footnote.innerHTML = `Note: ${ footnote }`;
       }
     }
 

--- a/src/js/components/standard-primary/index.js
+++ b/src/js/components/standard-primary/index.js
@@ -80,6 +80,11 @@ class StandardPrimary extends ElementBase {
     races.forEach(([race, element]) => {
       element.className = "race";
 
+      // carry over footnote if needed
+      if (typeof(race.footnote) != "undefined") {
+        race.results[0].footnote = race.footnote;
+      }
+
       toggleAttribute(element, "hidden", party && race.party != party);
       // create result tables
       var pairs = mapToElements(element, race.results, "results-table");


### PR DESCRIPTION
This update allows race-specific footnotes to be applied via the `footnotes` sheet in the config.

This presumably works for govs as well, though I did not test it.

To test: Take a look at Ohio House 6 and California special senate, then click around a few other states/races to be sure.