### PR TITLE
Post-election changes

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -97,7 +97,6 @@ document.addEventListener('npr:DataConsentChanged', () => {
 
 // listen for Data Consent overlay being closed on NPR.org
 window.addEventListener("message", event => {
-	console.log(event);
 	const origin = /.*npr\.org.*/g;
 	if (event.data == "Data consent updated" && origin.test(event.origin)) {
 	  OneTrust.Close();

--- a/src/js/calendar.js
+++ b/src/js/calendar.js
@@ -31,7 +31,7 @@ var pastMonths = months.filter(function(section) {
   return month < thisMonth;
 });
 
-if (pastMonths.length) {
+if (pastMonths.length > 0 && pastMonths.length < months.length - 1) {
   var previousLink = $.one("#jump-to-past");
   previousLink.classList.add("show");
 

--- a/src/partials/_footer.html
+++ b/src/partials/_footer.html
@@ -36,6 +36,7 @@
       <ul>
         <!-- <li><a href="https://www.npr.org/live-updates/super-tuesday-2024-states-results">Live coverage: Super Tuesday</a></li> -->
         <li><a href="https://www.npr.org/sections/elections/">Latest election news</a></li>
+        <li><a href="https://apps.npr.org/2024-election-results/">General election results</a></li>
         <li><a href="https://apps.npr.org/voter-registration-2024-mail/">Voter registration</a></li>
         <li><a href="https://apps.npr.org/primary-election-results-2024/">2024 election calendar</a></li>
         <li><a href="https://www.npr.org/2023/07/20/1185762259/trump-criminal-civil-cases-lawsuits">Trump's trials</a></li>

--- a/src/partials/_nav.html
+++ b/src/partials/_nav.html
@@ -9,8 +9,8 @@
     <ul class="primary">
       <li class="npr"><a href="https://npr.org"><img src="<%= prefix %>assets/logo.svg" alt="NPR" /></a></li>
       <li class="election"><a href="https://www.npr.org/sections/elections/"><img src="<%= prefix %>assets/synced/elections-2024-logo-color-horizontal.svg" alt="2024 Election" /></a></li>
-      <li><a href="https://apps.npr.org/primary-election-results-2024">Key dates & results</a></li>
-      <li><a href="https://apps.npr.org/voter-registration-2024-mail/">Voter registration</li>
+      <li><a href="https://apps.npr.org/2024-election-results/">General election</a></li>
+      <li><a href="https://apps.npr.org/primary-election-results-2024">Primaries & caucuses</a></li>
       <li><a href="https://www.npr.org/newsletter/politics">Newsletter</a></li>
     </ul>
 


### PR DESCRIPTION
- Edited links in navbar and footer to include general election results
- On the calendar, if there's only one month left, don't move past months to the bottom and don't show "Jump to past months" button
- Removed a console log